### PR TITLE
ShowOrderBookCmd

### DIFF
--- a/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
@@ -28,12 +28,12 @@ case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
 
       console.println(s"Order book for token $tokenId:")
       console.println("Sell orders:")
-      console.println("Amount   Total(including DEX fee)")
-      sellOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }
+      console.println("  Amount   Total(including DEX fee)")
+      sellOrders.foreach { o => console.println(f"${o.tokenAmount}%8d   ${o.tokenPriceWithDexFee}") }
 
       console.println("Buy orders:")
-      console.println("Amount   Total(including DEX fee)")
-      buyOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }
+      console.println("  Amount   Total(including DEX fee)")
+      buyOrders.foreach { o => console.println(f"${o.tokenAmount}%8d   ${o.tokenPriceWithDexFee}") }
     })
   }
 }

--- a/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
@@ -1,0 +1,80 @@
+package org.ergoplatform.appkit.ergotool.dex
+
+import org.ergoplatform.appkit.JavaHelpers._
+import org.ergoplatform.appkit.Parameters.MinFee
+import org.ergoplatform.appkit._
+import org.ergoplatform.appkit.config.ErgoToolConfig
+import org.ergoplatform.appkit.ergotool.{AppContext, Cmd, CmdDescriptor, RunWithErgoClient}
+
+/** Shows order book for AssetsAtomicExchange
+  */
+case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
+                                 name: String,
+                                 tokenId: ErgoId) extends Cmd with RunWithErgoClient {
+
+  override def runWithClient(ergoClient: ErgoClient, runCtx: AppContext): Unit = {
+    val console = runCtx.console
+    ergoClient.execute(ctx => {
+      val sellerHolderBoxes = loggedStep(s"Loading seller boxes", console) {
+        ctx.getUnspentBoxesForErgoTreeTemplate(SellerContract.contractTemplate).convertTo[IndexedSeq[InputBox]]
+      }
+      val buyerHolderBoxes = loggedStep(s"Loading buyer boxes", console) {
+        ctx.getUnspentBoxesForErgoTreeTemplate(BuyerContract.contractTemplate).convertTo[IndexedSeq[InputBox]]
+      }
+      val sellOrders = ShowOrderBook.sellOrders(sellerHolderBoxes, tokenId)
+        .sortBy(_.tokenPriceWithDexFee)
+        .reverse
+
+      val buyOrders = ShowOrderBook.buyOrders(buyerHolderBoxes, tokenId)
+        .sortBy(_.tokenPriceWithDexFee)
+        .reverse
+
+      console.println("Sell orders:")
+      console.println("Amount   Total")
+      sellOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }
+
+      console.println("Buy orders:")
+      console.println("Amount   Total")
+      buyOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }
+    })
+  }
+}
+
+object ShowOrderBookCmd extends CmdDescriptor(
+  name = "dex:ListMatchingOrders", cmdParamSyntax = "",
+  description = "show matching token seller's and buyer's orders") {
+
+  override def createCmd(ctx: AppContext): Cmd = {
+    ListMatchingOrdersCmd(ctx.toolConf, name)
+  }
+}
+
+object ShowOrderBook {
+
+  case class SellOrder(seller: InputBox, tokenAmount: Long, tokenPriceWithDexFee: Long)
+  case class BuyOrder(buyer: InputBox, tokenAmount: Long, tokenPriceWithDexFee: Long)
+
+  def sellOrders(sellerBoxes: Seq[InputBox], tokenId: ErgoId): Seq[SellOrder] = 
+    sellerBoxes
+      .flatMap { sellerBox =>
+        for {
+          tokenPrice <- SellerContract.tokenPriceFromTree(sellerBox.getErgoTree)
+          token <- sellerBox.getTokens
+            .convertTo[IndexedSeq[ErgoToken]]
+            .filter(_.getId().equals(tokenId))
+            .headOption
+          tokenPriceWithDexFee = tokenPrice + sellerBox.getValue()
+        } yield SellOrder(sellerBox, token.getValue(), tokenPriceWithDexFee)
+      }
+
+  def buyOrders(buyerBoxes: Seq[InputBox], tokenId: ErgoId): Seq[BuyOrder] = 
+    buyerBoxes
+      .flatMap { buyerBox =>
+        for {
+          token <- BuyerContract.tokenFromContractTree(buyerBox.getErgoTree)
+            .filter(_.getId().equals(tokenId))
+          tokenPriceWithDexFee = buyerBox.getValue()
+        } yield BuyOrder(buyerBox, token.getValue(), tokenPriceWithDexFee)
+      }
+
+}

--- a/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
@@ -24,12 +24,7 @@ case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
         ctx.getUnspentBoxesForErgoTreeTemplate(BuyerContract.contractTemplate).convertTo[IndexedSeq[InputBox]]
       }
       val sellOrders = ShowOrderBook.sellOrders(sellerHolderBoxes, tokenId)
-        .sortBy(_.tokenPriceWithDexFee)
-        .reverse
-
       val buyOrders = ShowOrderBook.buyOrders(buyerHolderBoxes, tokenId)
-        .sortBy(_.tokenPriceWithDexFee)
-        .reverse
 
       console.println(s"Order book for token $tokenId:")
       console.println("Sell orders:")
@@ -75,6 +70,8 @@ object ShowOrderBook {
           tokenPriceWithDexFee = tokenPrice + sellerBox.getValue()
         } yield SellOrder(sellerBox, token.getValue(), tokenPriceWithDexFee)
       }
+    .sortBy(_.tokenPriceWithDexFee)
+    .reverse
 
   def buyOrders(buyerBoxes: Seq[InputBox], tokenId: ErgoId): Seq[BuyOrder] = 
     buyerBoxes
@@ -85,5 +82,7 @@ object ShowOrderBook {
           tokenPriceWithDexFee = buyerBox.getValue()
         } yield BuyOrder(buyerBox, token.getValue(), tokenPriceWithDexFee)
       }
+    .sortBy(_.tokenPriceWithDexFee)
+    .reverse
 
 }

--- a/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
@@ -5,8 +5,10 @@ import org.ergoplatform.appkit.Parameters.MinFee
 import org.ergoplatform.appkit._
 import org.ergoplatform.appkit.config.ErgoToolConfig
 import org.ergoplatform.appkit.ergotool.{AppContext, Cmd, CmdDescriptor, RunWithErgoClient}
+import org.ergoplatform.appkit.ergotool.CmdParameter
+import org.ergoplatform.appkit.ergotool.ErgoIdPType
 
-/** Shows order book for AssetsAtomicExchange
+/** Shows order book (sell and buy orders for a given token) for AssetsAtomicExchange
   */
 case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
                                  name: String,
@@ -41,11 +43,17 @@ case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
 }
 
 object ShowOrderBookCmd extends CmdDescriptor(
-  name = "dex:ListMatchingOrders", cmdParamSyntax = "",
-  description = "show matching token seller's and buyer's orders") {
+  name = "dex:ShowOrderBook", cmdParamSyntax = "<tokenId>",
+  description = "show order book, sell and buy order for a given token id") {
+
+  override val parameters: Seq[CmdParameter] = Array(
+    CmdParameter("tokenId", ErgoIdPType,
+      "token id to filter sell and buy orders")
+  )
 
   override def createCmd(ctx: AppContext): Cmd = {
-    ListMatchingOrdersCmd(ctx.toolConf, name)
+    val Seq(tokenId: ErgoId) = ctx.cmdParameters
+    ShowOrderBookCmd(ctx.toolConf, name, tokenId)
   }
 }
 

--- a/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
@@ -31,6 +31,7 @@ case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
         .sortBy(_.tokenPriceWithDexFee)
         .reverse
 
+      console.println(s"Order book for token $tokenId:")
       console.println("Sell orders:")
       console.println("Amount   Total")
       sellOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }

--- a/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookCmd.scala
@@ -33,11 +33,11 @@ case class ShowOrderBookCmd(toolConf: ErgoToolConfig,
 
       console.println(s"Order book for token $tokenId:")
       console.println("Sell orders:")
-      console.println("Amount   Total")
+      console.println("Amount   Total(including DEX fee)")
       sellOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }
 
       console.println("Buy orders:")
-      console.println("Amount   Total")
+      console.println("Amount   Total(including DEX fee)")
       buyOrders.foreach { o => console.println(f"${o.tokenAmount}%8d ${o.tokenPriceWithDexFee}") }
     })
   }

--- a/src/main/scala/org/ergoplatform/appkit/ergotool/ErgoTool.scala
+++ b/src/main/scala/org/ergoplatform/appkit/ergotool/ErgoTool.scala
@@ -6,6 +6,7 @@ import scala.util.control.NonFatal
 import org.ergoplatform.appkit.config.ErgoToolConfig
 import org.ergoplatform.appkit.console.Console
 import org.ergoplatform.appkit.ergotool.dex.{CancelOrderCmd, CreateBuyOrderCmd, CreateSellOrderCmd, IssueTokenCmd, ListMatchingOrdersCmd, ListMyOrdersCmd, MatchOrdersCmd}
+import org.ergoplatform.appkit.ergotool.dex.ShowOrderBookCmd
 
 /** ErgoTool implementation, contains main entry point of the console application.
   *
@@ -19,7 +20,7 @@ object ErgoTool {
     ListAddressBoxesCmd,
     CreateStorageCmd, ExtractStorageCmd, SendCmd,
     CreateSellOrderCmd, CreateBuyOrderCmd, MatchOrdersCmd,
-    ListMatchingOrdersCmd, IssueTokenCmd, CancelOrderCmd, ListMyOrdersCmd
+    ListMatchingOrdersCmd, IssueTokenCmd, CancelOrderCmd, ListMyOrdersCmd, ShowOrderBookCmd
     ).map(c => (c.name, c)).toMap
 
   /** Options supported by this application */

--- a/src/test/scala/org/ergoplatform/appkit/ObjectGenerators.scala
+++ b/src/test/scala/org/ergoplatform/appkit/ObjectGenerators.scala
@@ -25,12 +25,13 @@ trait ObjectGenerators {
   val testnetAddressGen: Gen[Address] = addressGen(NetworkType.TESTNET.networkPrefix)
 
   val unsignedLongGen: Gen[Long] = Gen.chooseNum(0, Long.MaxValue)
+  val positiveLongGen: Gen[Long] = Gen.chooseNum(1, Long.MaxValue)
 
   val validBoxValueGen: Gen[Long] = Gen.chooseNum(Parameters.MinFee, Long.MaxValue)
 
   val tokenGen: Gen[ErgoToken] = for {
     id <- ergoIdGen
-    value <- unsignedLongGen
+    value <- positiveLongGen
   } yield new ErgoToken(id, value)
 
   val sellOrderContractGen: Gen[ErgoContract] = for {
@@ -45,7 +46,7 @@ trait ObjectGenerators {
   def sellOrderBoxGen(sellerAddress: Address): Gen[InputBox] = for {
     id <- ergoIdGen
     value <- validBoxValueGen
-    tokenPrice <- Gen.chooseNum(1L, Long.MaxValue)
+    tokenPrice <- positiveLongGen
     token <- tokenGen
   } yield {
     val ergoTree = SellerContract.contractInstance(tokenPrice, sellerAddress).getErgoTree

--- a/src/test/scala/org/ergoplatform/appkit/ergotool/ErgoToolSpec.scala
+++ b/src/test/scala/org/ergoplatform/appkit/ergotool/ErgoToolSpec.scala
@@ -647,7 +647,8 @@ class ErgoToolSpec
       expectedConsoleScenario = "",
       data)
     println(res)
-    res should not include ("60  55000000")
+    res should include ("  Amount   Total(including DEX fee)")
+    res should include ("      60   55000000")
   }
 
 }

--- a/src/test/scala/org/ergoplatform/appkit/ergotool/ErgoToolSpec.scala
+++ b/src/test/scala/org/ergoplatform/appkit/ergotool/ErgoToolSpec.scala
@@ -621,5 +621,34 @@ class ErgoToolSpec
     res should not include ("655ad79f579677fa0f44e72713ecd8f054e534a02e66d8aef4fc2729b9e62b76 21f84cf457802e66fb5930fb5d45fbe955933dc16a72089bf8980797f24e2fa1 60            50000000     5000000")
     res should not include ("969482db6643a16b6d8f4c8b50d0a9d5b47a698014c927ee0fa495e2adabbb8e 21f84cf457802e66fb5930fb5d45fbe955933dc16a72089bf8980797f24e2fa1 60            55000000")
   }
+
+  property("dex:ShowOrderBook command") {
+    val data = MockData(
+      Seq(
+        loadNodeResponse("response_Box_AAE_seller_contract.json"),
+        loadNodeResponse("response_Box1.json"),
+        loadNodeResponse("response_Box2.json"),
+        loadNodeResponse("response_Box3.json"),
+        loadNodeResponse("response_Box_AAE_buyer_contract.json"),
+        loadNodeResponse("response_Box1.json"),
+        loadNodeResponse("response_Box2.json"),
+        loadNodeResponse("response_Box3.json"),
+        ),
+      Seq(
+        loadExplorerResponse("response_boxesByAddressUnspent.json"),
+        loadExplorerResponse("response_boxesByAddressUnspent.json")
+      )
+    )
+
+    val res = runCommand("dex:ShowOrderBook",
+      args = Seq(
+        "21f84cf457802e66fb5930fb5d45fbe955933dc16a72089bf8980797f24e2fa1"
+      ),
+      expectedConsoleScenario = "",
+      data)
+    println(res)
+    res should not include ("60  55000000")
+  }
+
 }
 

--- a/src/test/scala/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookSpec.scala
+++ b/src/test/scala/org/ergoplatform/appkit/ergotool/dex/ShowOrderBookSpec.scala
@@ -1,0 +1,79 @@
+package org.ergoplatform.appkit.ergotool.dex
+
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import ShowOrderBook._
+import ListMatchingOrders._
+import org.ergoplatform.appkit.{Address, ErgoId, ErgoToken, InputBox, MockInputBox, NetworkType, ObjectGenerators}
+import org.ergoplatform.appkit.Parameters.MinFee
+import org.scalacheck.Gen
+
+class ShowOrderBookSpec extends PropSpec
+  with Matchers
+  with ScalaCheckDrivenPropertyChecks
+  with ObjectGenerators {
+
+  val tokenId = ergoIdGen.sample.get
+
+  property("empty list (no input)") {
+    sellOrders(Seq.empty, tokenId) shouldBe empty
+    buyOrders(Seq.empty, tokenId) shouldBe empty
+  }
+
+  property("empty list (no valid contracts in inputs)") {
+    sellOrders(Seq(MockInputBox(1L)), tokenId) shouldBe empty
+    buyOrders(Seq(MockInputBox(1L)), tokenId) shouldBe empty
+  }
+
+  property("empty sell order list (no matching token)") {
+    val sellerContract = SellerContract.contractInstance(1L,
+      testnetAddressGen.sample.get)
+    val sellerBox = MockInputBox(ergoIdGen.sample.get, 1L, sellerContract.getErgoTree,
+      Seq(new ErgoToken(ergoIdGen.sample.get, 1L)))
+    sellOrders(Seq(sellerBox), tokenId) shouldBe empty
+  }
+
+  property("empty buy order list (no matching token)") {
+    val buyerContract = BuyerContract.contractInstance(new ErgoToken(ergoIdGen.sample.get, 1L),
+      testnetAddressGen.sample.get)
+    val buyerBox = MockInputBox(ergoIdGen.sample.get, 1L, buyerContract.getErgoTree)
+    buyOrders(Seq(buyerBox), tokenId) shouldBe empty
+  }
+
+  property("BuyOrder properties") {
+    forAll(positiveLongGen, validBoxValueGen) { case (tokenAmount, tokenPriceWithDexFee) =>
+      val buyerContract = BuyerContract.contractInstance(new ErgoToken(tokenId, tokenAmount),
+        testnetAddressGen.sample.get)
+      val buyerBox = MockInputBox(ergoIdGen.sample.get, tokenPriceWithDexFee, buyerContract.getErgoTree)
+      val expectedBuyOrder = BuyOrder(buyerBox, tokenAmount, tokenPriceWithDexFee)
+      buyOrders(Seq(buyerBox), tokenId) shouldBe Seq(expectedBuyOrder)
+    }
+  }
+
+  property("SellOrder properties") {
+    forAll(positiveLongGen, positiveLongGen, validBoxValueGen) { case (tokenPrice, tokenAmount, dexFee) =>
+      val sellerContract = SellerContract.contractInstance(tokenPrice, testnetAddressGen.sample.get)
+      val sellerBox = MockInputBox(ergoIdGen.sample.get, dexFee, sellerContract.getErgoTree,
+        Seq(new ErgoToken(tokenId, tokenAmount)))
+      val expectedSellOrder = SellOrder(sellerBox, tokenAmount, tokenPrice + dexFee)
+      sellOrders(Seq(sellerBox), tokenId) shouldBe Seq(expectedSellOrder)
+    }
+  }
+
+  property("many buy orders, sorting") {
+    val buyerContract = BuyerContract.contractInstance(new ErgoToken(tokenId, 1L),
+      testnetAddressGen.sample.get)
+    val buyerBox = MockInputBox(ergoIdGen.sample.get, 1L, buyerContract.getErgoTree)
+    val buyerBox2 = MockInputBox(ergoIdGen.sample.get, 2L, buyerContract.getErgoTree)
+    buyOrders(Seq(buyerBox, buyerBox2), tokenId).map(_.tokenPriceWithDexFee) shouldEqual Seq(2L, 1L)
+  }
+
+  property("many sell orders, sorting") {
+    val sellerContract = SellerContract.contractInstance(1L, testnetAddressGen.sample.get)
+    val sellerBox = MockInputBox(ergoIdGen.sample.get, 1L, sellerContract.getErgoTree,
+      Seq(new ErgoToken(tokenId, 1L)))
+    val sellerBox2 = MockInputBox(ergoIdGen.sample.get, 2L, sellerContract.getErgoTree,
+      Seq(new ErgoToken(tokenId, 1L)))
+    sellOrders(Seq(sellerBox, sellerBox2), tokenId).map(_.tokenPriceWithDexFee) shouldEqual Seq(3L, 2L)
+  }
+}


### PR DESCRIPTION
Close #26 

Todo: 
- [x] tests

Review notes:
- Buy order holds token price **and** DEX fee in the `box.value`. There is no way of distinguishing them AFAIK. I called the column "Total(including DEX fee)". I adopted it for sell orders as well and show the sum of sell order's DEX fee(`box.value`) and token price from the order's contract. To have a common ground for comparison between buy and sell orders.