### PR TITLE
add new commands to the ergo tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,16 @@ Available actions:
 	Creates an encrypted storage file for the mnemonic entered by user
   extractStorage <storage file> address|masterKey|publicKey|secretKey mainnet|testnet
 	Reads the file, unlocks it using password and extract the requested property from the given storage file.
+  extractStorage <storage file> address|masterKey|publicKey|secretKey mainnet|testnet
+        Reads the file, unlocks it using password and extract the requested property from the given storage file.
+  getBoxInfo <boxId>
+        list box content with tokens and register details
   help <commandName>
-	prints usage help for a command
-  listAddressBoxes address [<limit>=10]
-	list top <limit=10> confirmed unspent boxes owned by the given <address>
+        prints usage help for a command
+  listAddressBoxes [--limit-list <limit>] <address>
+        list top <limit> confirmed unspent boxes owned by the given <address>
+  listAddressTokens <address>
+        list tokens owned by the given <address>
   mnemonic 
 	generate new mnemonic phrase using english words and default cryptographic strength
   send <storageFile> <recipientAddr> <amountToSend>
@@ -198,8 +204,10 @@ Click on the command name to open its detailed description.
  [checkAddress](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/CheckAddressCmd.html) | `<networkType> <mnemonic> <address>` <br/> Check the given mnemonic and password pair correspond to the given address
  [createStorage](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/CreateStorageCmd.html) | `[<storageDir>="storage"] [<storageFileName>="secret.json"]` <br/> Creates an encrypted storage file for the mnemonic entered by user
  [extractStorage](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/ExtractStorageCmd.html) | `<storage file> <property> <networkType>` <br/> Reads the file, unlocks it using password and extract the requested property from the given storage file. Where `property` is one of `address`, `masterKey`, `publicKey`, `secretKey`
+ [getBoxInfo](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/GetBoxInfoCmd.html) | `boxId` <br/> list box content with tokens and register details
  [help](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/HelpCmd.html) | `<commandName>` <br/> prints usage help for a command
  [listAddressBoxes](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/ListAddressBoxesCmd.html) | `address [<limit>=10]` <br/> list top `limit=10` confirmed unspent boxes owned by the given `address`
+ [listAddressTokens](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/ListAddressTokensCmd.html) | `address` <br/> list tokens owned by the given `address`
  [mnemonic](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/MnemonicCmd.html) | generate new mnemonic phrase using english words and default cryptographic strength
  [send](https://ergoplatform.github.io/ergo-tool/api/org/ergoplatform/appkit/ergotool/SendCmd.html) | `<storageFile> <recipientAddr> <amountToSend>` <br/> send the given `amountToSend` to the given `recipientAddr` using the given `wallet file` to sign the transaction (it will also request storage password)
          

--- a/src/main/scala/org/ergoplatform/appkit/ergotool/ErgoTool.scala
+++ b/src/main/scala/org/ergoplatform/appkit/ergotool/ErgoTool.scala
@@ -14,7 +14,7 @@ object ErgoTool extends CliApplication {
   /** Commands supported by this application. */
   override def commands: Seq[CmdDescriptor] = super.commands ++ Array(
     AddressCmd, MnemonicCmd, CheckAddressCmd,
-    ListAddressBoxesCmd,
+    ListAddressBoxesCmd, ListAddressTokensCmd, GetBoxInfoCmd,
     CreateStorageCmd, ExtractStorageCmd, SendCmd
   )
 

--- a/src/main/scala/org/ergoplatform/appkit/ergotool/GetBoxInfoCmd.scala
+++ b/src/main/scala/org/ergoplatform/appkit/ergotool/GetBoxInfoCmd.scala
@@ -1,0 +1,44 @@
+package org.ergoplatform.appkit.ergotool
+
+import org.ergoplatform.appkit.cli.AppContext
+import org.ergoplatform.appkit.commands.{Cmd, CmdDescriptor, CmdParameter, RunWithErgoClient, StringPType}
+import org.ergoplatform.appkit.config.ErgoToolConfig
+import org.ergoplatform.appkit.ErgoClient
+import scala.collection.convert.ImplicitConversions.`iterable AsScalaIterable`
+
+/** Get the details about a boxId (value, tokens, registers and the ergotree)
+  *
+  * @param boxId string encoding of the address
+  */
+case class GetBoxInfoCmd(toolConf: ErgoToolConfig, name: String, boxId: String) extends Cmd with RunWithErgoClient {
+  override def runWithClient(ergoClient: ErgoClient, runCtx: AppContext): Unit = {
+    val res: String = ergoClient.execute(ctx => {
+      val boxes = ctx.getBoxesById(boxId)
+      val box = boxes(0)
+      val lines = if (runCtx.isPrintJson) {
+        box.toJson(false)
+      } else {
+        "BoxId: " + box.getId +
+          "\nNanoERGs: " + box.getValue +
+          "\nTokens: \n" + box.getTokens.map( e => s"    TokenId: ${e.getId} Amount: ${e.getValue}").mkString("\n") +
+          "\nRegisters: \n" + box.getRegisters.map( r => s"    Type: ${r.getType} Value: ${r.getValue}").mkString("\n") +
+          "\nErgoTree: " + box.getErgoTree
+      }
+      lines
+    })
+    runCtx.console.print(res)
+  }
+}
+object GetBoxInfoCmd extends CmdDescriptor(
+  name = "getBoxInfo", cmdParamSyntax = "<boxId>",
+  description = "list box content with tokens and register details") {
+
+  override val parameters: Seq[CmdParameter] = Array(
+    CmdParameter("boxId", StringPType, "id of the box")
+  )
+
+  override def createCmd(ctx: AppContext): Cmd = {
+    val Seq(boxId: String) = ctx.cmdParameters
+    GetBoxInfoCmd(ctx.toolConf, name, boxId)
+  }
+}

--- a/src/main/scala/org/ergoplatform/appkit/ergotool/ListAddressTokensCmd.scala
+++ b/src/main/scala/org/ergoplatform/appkit/ergotool/ListAddressTokensCmd.scala
@@ -1,0 +1,50 @@
+package org.ergoplatform.appkit.ergotool
+
+import org.ergoplatform.appkit.cli.AppContext
+import org.ergoplatform.appkit.commands.{AddressPType, Cmd, CmdDescriptor, CmdParameter, RunWithErgoClient}
+import org.ergoplatform.appkit.config.ErgoToolConfig
+import org.ergoplatform.appkit.{Address, ErgoClient, InputBox}
+
+import scala.collection.convert.ImplicitConversions.`iterable AsScalaIterable`
+
+/** Lists tokens (can be NFTs or Tokens) belonging to the given address.
+  *
+  * @param address string encoding of the address
+  */
+case class ListAddressTokensCmd(toolConf: ErgoToolConfig, name: String, address: Address) extends Cmd with RunWithErgoClient {
+  override def runWithClient(ergoClient: ErgoClient, runCtx: AppContext): Unit = {
+    val res: String = ergoClient.execute(ctx => {
+      val boxes = ctx.getUnspentBoxesFor(address)
+      val boxesWithTokens: Iterable[InputBox] = boxes.filter(_.getTokens.size() > 0)
+      val lines = if (runCtx.isPrintJson) {
+        val ret = for (b <- boxesWithTokens) yield {
+          val tokens = b.getTokens
+          tokens.map(t => "{\"tokenId\":\"" + t.getId + "\",\"amount\":" + t.getValue + "}" ).mkString("", ",\n", "")
+        }
+        ret.mkString("[", ",\n", "]")
+      } else {
+        val ret = for (b <- boxesWithTokens) yield {
+                val tokens = b.getTokens
+                tokens.map(t => s"${t.getId} ${t.getValue}").mkString("", "\n", "")
+             }
+        "TokenId                                                          Amount          \n" +
+        ret.mkString("", "\n", "")
+      }
+      lines
+    })
+    runCtx.console.print(res)
+  }
+}
+object ListAddressTokensCmd extends CmdDescriptor(
+  name = "listAddressTokens", cmdParamSyntax = "<address>",
+  description = "list tokens owned by the given <address>") {
+
+  override val parameters: Seq[CmdParameter] = Array(
+    CmdParameter("address", AddressPType, "string encoding of the address")
+  )
+
+  override def createCmd(ctx: AppContext): Cmd = {
+    val Seq(address: Address) = ctx.cmdParameters
+    ListAddressTokensCmd(ctx.toolConf, name, address)
+  }
+}

--- a/src/test/scala/org/ergoplatform/appkit/ergotool/ErgoToolSpec.scala
+++ b/src/test/scala/org/ergoplatform/appkit/ergotool/ErgoToolSpec.scala
@@ -84,6 +84,34 @@ class ErgoToolSpec
     res should include ("e050a3af38241ce444c34eb25c0ab880674fc23a0e63632633ae14f547141c37")
     res should include ("26d6e08027e005270b38e5c5f4a73ffdb6d65a3289efb51ac37f98ad395d887c")
   }
+  
+  property("getBoxInfo command") {
+    val data = MockData(
+      Seq(
+        loadNodeResponse("response_Box4.json")),
+    Seq(
+        loadExplorerResponse("response_boxesByAddressUnspent.json")))
+    val res = runCommand(ErgoTool, "getBoxInfo", Seq("356037af6e85980113f3071ec7b010202448a231ce74e441c0aae7241d82a20e"),
+      expectedConsoleScenario = "", data)
+    res should include ("356037af6e85980113f3071ec7b010202448a231ce74e441c0aae7241d82a20e")
+    res should include ("21f84cf457802e66fb5930fb5d45fbe955933dc16a72089bf8980797f24e2fa1")
+    res should include ("Amount: 60")
+    res should include ("ErgoTree(0,WrappedArray(),Right")
+  }
+  
+  property("listAddressTokens command") {
+    val data = MockData(
+      Seq(
+        loadNodeResponse("response_Box1.json"),
+        loadNodeResponse("response_Box2.json"),
+        loadNodeResponse("response_Box3.json"),
+        loadNodeResponse("response_Box4.json")),
+    Seq(
+        loadExplorerResponse("response_boxesByAddressUnspent.json")))
+    val res = runCommand(ErgoTool, "listAddressTokens", Seq("9hHDQb26AjnJUXxcqriqY1mnhpLuUeC81C4pggtK7tupr92Ea1K"),
+      expectedConsoleScenario = "", data)
+    res should include ("21f84cf457802e66fb5930fb5d45fbe955933dc16a72089bf8980797f24e2fa1 60")
+  }
 
   property("createStorage and extractStorage commands") {
     import ExtractStorageCmd._


### PR DESCRIPTION
Proposing two news commands to get more information about an address:  
  - list tokens from an address
  - get the detailed content of a box

I have not found a way from the appkit to display the name of the tokens.
